### PR TITLE
refactor: reduce cognitive complexity in 3 remaining SonarCloud findings

### DIFF
--- a/scripts/content/upload_to_confluence.py
+++ b/scripts/content/upload_to_confluence.py
@@ -217,6 +217,13 @@ def markdown_to_confluence(markdown_text):
             html_parts.append(html)
             continue
 
+        # Checkboxes before bullets — `- [x]` matches both patterns
+        checkbox = _convert_checkbox(line)
+        if checkbox:
+            html_parts.append(checkbox)
+            i += 1
+            continue
+
         if _BULLET_RE.match(line):
             html, i = _convert_list_block(lines, i, _BULLET_RE, "ul")
             html_parts.append(html)
@@ -231,12 +238,6 @@ def markdown_to_confluence(markdown_text):
         heading = _convert_heading(line)
         if heading:
             html_parts.append(heading)
-            i += 1
-            continue
-
-        checkbox = _convert_checkbox(line)
-        if checkbox:
-            html_parts.append(checkbox)
             i += 1
             continue
 

--- a/scripts/content/upload_to_confluence.py
+++ b/scripts/content/upload_to_confluence.py
@@ -138,6 +138,55 @@ def _collect_list_items(lines, i, pattern):
     return items, i
 
 
+def _convert_heading(line):
+    """Convert a heading line to Confluence HTML, or return None."""
+    heading_match = _HEADING_RE.match(line)
+    if not heading_match:
+        return None
+    level = len(heading_match.group(1))
+    text = _inline(heading_match.group(2))
+    return f"<h{level}>{text}</h{level}>"
+
+
+def _convert_checkbox(line):
+    """Convert a checkbox line to Confluence HTML, or return None."""
+    checkbox_match = _CHECKBOX_RE.match(line)
+    if not checkbox_match:
+        return None
+    checked = checkbox_match.group(1).lower() == "x"
+    text = _inline(checkbox_match.group(2))
+    icon = "(/)" if checked else "(x)"
+    return f"<p>{icon} {text}</p>"
+
+
+def _convert_list_block(lines, i, pattern, tag):
+    """Convert a bullet or numbered list block to Confluence HTML.
+
+    Returns:
+        tuple: (html_string, new_line_index)
+    """
+    items, i = _collect_list_items(lines, i, pattern)
+    html = f"<{tag}>" + "".join(f"<li>{it}</li>" for it in items) + f"</{tag}>"
+    return html, i
+
+
+def _convert_single_line(line):
+    """Try to convert a single-line block element (blockquote, hr, paragraph).
+
+    Returns:
+        str or None: HTML string, or None if the line is empty.
+    """
+    stripped = line.strip()
+    if stripped.startswith(">"):
+        text = _inline(re.sub(r"^>\s?", "", stripped))
+        return f"<blockquote><p>{text}</p></blockquote>"
+    if _HORIZONTAL_RULE_RE.match(stripped):
+        return "<hr/>"
+    if stripped:
+        return f"<p>{_inline(stripped)}</p>"
+    return None
+
+
 def markdown_to_confluence(markdown_text):
     """Convert markdown text to Confluence storage format (XHTML).
 
@@ -157,70 +206,43 @@ def markdown_to_confluence(markdown_text):
     while i < len(lines):
         line = lines[i]
 
-        # Code block
+        # Multi-line blocks (code, table, lists) advance i themselves
         if line.strip().startswith(_CODE_FENCE):
             html, i = _convert_code_block(lines, i)
             html_parts.append(html)
             continue
 
-        # Table
         if line.strip().startswith("|"):
             html, i = _convert_table_block(lines, i)
             html_parts.append(html)
             continue
 
-        # Heading
-        heading_match = _HEADING_RE.match(line)
-        if heading_match:
-            level = len(heading_match.group(1))
-            text = _inline(heading_match.group(2))
-            html_parts.append(f"<h{level}>{text}</h{level}>")
-            i += 1
-            continue
-
-        # Checkbox
-        checkbox_match = _CHECKBOX_RE.match(line)
-        if checkbox_match:
-            checked = checkbox_match.group(1).lower() == "x"
-            text = _inline(checkbox_match.group(2))
-            icon = "(/)" if checked else "(x)"
-            html_parts.append(f"<p>{icon} {text}</p>")
-            i += 1
-            continue
-
-        # Bullet list
         if _BULLET_RE.match(line):
-            items, i = _collect_list_items(lines, i, _BULLET_RE)
-            html_parts.append(
-                "<ul>" + "".join(f"<li>{it}</li>" for it in items) + "</ul>"
-            )
+            html, i = _convert_list_block(lines, i, _BULLET_RE, "ul")
+            html_parts.append(html)
             continue
 
-        # Numbered list
         if _NUMBERED_RE.match(line):
-            items, i = _collect_list_items(lines, i, _NUMBERED_RE)
-            html_parts.append(
-                "<ol>" + "".join(f"<li>{it}</li>" for it in items) + "</ol>"
-            )
+            html, i = _convert_list_block(lines, i, _NUMBERED_RE, "ol")
+            html_parts.append(html)
             continue
 
-        # Blockquote
-        if line.strip().startswith(">"):
-            text = _inline(re.sub(r"^>\s?", "", line.strip()))
-            html_parts.append(f"<blockquote><p>{text}</p></blockquote>")
+        # Single-line block elements
+        heading = _convert_heading(line)
+        if heading:
+            html_parts.append(heading)
             i += 1
             continue
 
-        # Horizontal rule
-        if _HORIZONTAL_RULE_RE.match(line.strip()):
-            html_parts.append("<hr/>")
+        checkbox = _convert_checkbox(line)
+        if checkbox:
+            html_parts.append(checkbox)
             i += 1
             continue
 
-        # Paragraph
-        stripped = line.strip()
-        if stripped:
-            html_parts.append(f"<p>{_inline(stripped)}</p>")
+        result = _convert_single_line(line)
+        if result:
+            html_parts.append(result)
 
         i += 1
 

--- a/scripts/content/upload_to_docs.py
+++ b/scripts/content/upload_to_docs.py
@@ -469,6 +469,59 @@ def _emit_numbered(line_match, index):
 # Markdown -> Docs requests: main converter
 # ---------------------------------------------------------------------------
 
+def _try_multiline_block(lines, i, index):
+    """Handle multi-line blocks (code, table) that advance their own line index.
+
+    Returns:
+        tuple: (requests, new_i, new_index) or None if no match.
+    """
+    line = lines[i]
+    if line.strip().startswith(_CODE_FENCE):
+        return _emit_code_block(lines, i, index)
+    if line.strip().startswith("|") and i + 1 < len(lines):
+        return _emit_table(lines, i, index)
+    return None
+
+
+def _try_single_line_block(line, index):
+    """Handle single-line block elements (hr, heading, blockquote, lists).
+
+    Returns:
+        tuple: (requests, new_index) or None if no match.
+    """
+    if _HORIZONTAL_RULE_RE.match(line.strip()):
+        return _emit_horizontal_rule(index)
+
+    heading_match = _HEADING_RE.match(line)
+    if heading_match:
+        return _emit_heading(heading_match, index)
+
+    if line.strip().startswith(">"):
+        return _emit_blockquote(line, index)
+
+    bullet_match = _BULLET_RE.match(line)
+    if bullet_match:
+        return _emit_bullet(bullet_match, index)
+
+    num_match = _NUMBERED_RE.match(line)
+    if num_match:
+        return _emit_numbered(num_match, index)
+
+    return None
+
+
+def _emit_paragraph_or_blank(line, index):
+    """Emit requests for a plain paragraph or empty-line spacer.
+
+    Returns:
+        tuple: (requests, new_index)
+    """
+    if line.strip():
+        para_text = line.strip() + "\n"
+        return process_inline_formatting(para_text, index)
+    return [{"insertText": {"location": {"index": index}, "text": "\n"}}], index + 1
+
+
 def markdown_to_docs_requests(markdown_text):
     """Convert full markdown text to a list of Google Docs API requests.
 
@@ -487,71 +540,24 @@ def markdown_to_docs_requests(markdown_text):
     while i < len(lines):
         line = lines[i]
 
-        # Code block
-        if line.strip().startswith(_CODE_FENCE):
-            reqs, i, index = _emit_code_block(lines, i, index)
+        # Multi-line blocks advance i themselves
+        multi = _try_multiline_block(lines, i, index)
+        if multi:
+            reqs, i, index = multi
             all_requests.extend(reqs)
             continue
 
-        # Table
-        if line.strip().startswith("|") and i + 1 < len(lines):
-            reqs, i, index = _emit_table(lines, i, index)
-            all_requests.extend(reqs)
-            continue
-
-        # Horizontal rule
-        if _HORIZONTAL_RULE_RE.match(line.strip()):
-            reqs, index = _emit_horizontal_rule(index)
+        # Single-line block elements
+        single = _try_single_line_block(line, index)
+        if single:
+            reqs, index = single
             all_requests.extend(reqs)
             i += 1
             continue
 
-        # Heading
-        heading_match = _HEADING_RE.match(line)
-        if heading_match:
-            reqs, index = _emit_heading(heading_match, index)
-            all_requests.extend(reqs)
-            i += 1
-            continue
-
-        # Blockquote
-        if line.strip().startswith(">"):
-            reqs, index = _emit_blockquote(line, index)
-            all_requests.extend(reqs)
-            i += 1
-            continue
-
-        # Bullet list
-        bullet_match = _BULLET_RE.match(line)
-        if bullet_match:
-            reqs, index = _emit_bullet(bullet_match, index)
-            all_requests.extend(reqs)
-            i += 1
-            continue
-
-        # Numbered list
-        num_match = _NUMBERED_RE.match(line)
-        if num_match:
-            reqs, index = _emit_numbered(num_match, index)
-            all_requests.extend(reqs)
-            i += 1
-            continue
-
-        # Plain paragraph (skip empty lines)
-        if line.strip():
-            para_text = line.strip() + "\n"
-            inline_reqs, index = process_inline_formatting(para_text, index)
-            all_requests.extend(inline_reqs)
-        else:
-            # Empty line -> newline for spacing
-            all_requests.append({
-                "insertText": {
-                    "location": {"index": index},
-                    "text": "\n",
-                }
-            })
-            index += 1
-
+        # Plain paragraph or empty line
+        reqs, index = _emit_paragraph_or_blank(line, index)
+        all_requests.extend(reqs)
         i += 1
 
     return all_requests

--- a/scripts/core/preflight_check.py
+++ b/scripts/core/preflight_check.py
@@ -264,6 +264,62 @@ def attempt_google_token(token_path: Path, scopes: list) -> Tuple[bool, str]:
 # Main
 # ---------------------------------------------------------------------------
 
+def _run_checks(checks):
+    """Run all checks and return (results_list, failure_count)."""
+    results = []
+    failures = 0
+    for name, fn in checks:
+        ok, detail = fn()
+        results.append((name, ok, detail))
+        print_result(name, ok, detail)
+        if not ok:
+            failures += 1
+    return results, failures
+
+
+def _attempt_fixes(failed_names):
+    """Attempt automated fixes for known failure categories."""
+    fix_actions = []
+
+    if {"Atlassian", "Slack", "Glean"} & failed_names:
+        ok, detail = ensure_env_symlink()
+        fix_actions.append(("Env file", ok, detail))
+
+    if "Google Drive" in failed_names:
+        ok, detail = attempt_google_token(
+            SCRIPT_DIR / "token.json",
+            ["https://www.googleapis.com/auth/drive.readonly"],
+        )
+        fix_actions.append(("Google Drive token", ok, detail))
+
+    if MSG_GOOGLE_DOCS_TOKEN in failed_names:
+        ok, detail = attempt_google_token(
+            SCRIPT_DIR / "token_docs.json",
+            [
+                "https://www.googleapis.com/auth/drive.file",
+                "https://www.googleapis.com/auth/documents",
+            ],
+        )
+        fix_actions.append((MSG_GOOGLE_DOCS_TOKEN, ok, detail))
+
+    for name, ok, detail in fix_actions:
+        print_result(f"{name} fix", ok, detail)
+
+
+def _build_checks(args):
+    """Build the list of (name, check_fn) pairs from CLI args."""
+    check_registry = {
+        "google_drive": ("Google Drive", check_google_drive),
+        "google_docs": (MSG_GOOGLE_DOCS_TOKEN, check_google_docs_token),
+        "atlassian": ("Atlassian", check_atlassian),
+        "slack": ("Slack", check_slack),
+        "glean": ("Glean", check_glean),
+    }
+    if args.service == "all":
+        return list(check_registry.values())
+    return [check_registry[args.service]]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Preflight access check")
     parser.add_argument(
@@ -284,68 +340,19 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    check_registry = {
-        "google_drive": ("Google Drive", check_google_drive),
-        "google_docs": (MSG_GOOGLE_DOCS_TOKEN, check_google_docs_token),
-        "atlassian": ("Atlassian", check_atlassian),
-        "slack": ("Slack", check_slack),
-        "glean": ("Glean", check_glean),
-    }
-    if args.service == "all":
-        checks = list(check_registry.values())
-    else:
-        checks = [check_registry[args.service]]
+    checks = _build_checks(args)
 
-    failures = 0
     print("Preflight Access Check")
     print("=" * 28)
-    results = []
-    for name, fn in checks:
-        ok, detail = fn()
-        results.append((name, ok, detail))
-        print_result(name, ok, detail)
-        if not ok:
-            failures += 1
+    results, failures = _run_checks(checks)
 
     if failures and args.attempt_fix:
-        print()
-        print("Attempting fixes...")
+        print("\nAttempting fixes...")
         failed_names = {name for name, ok, _ in results if not ok}
-        fix_actions = []
+        _attempt_fixes(failed_names)
 
-        if {"Atlassian", "Slack", "Glean"} & failed_names:
-            ok, detail = ensure_env_symlink()
-            fix_actions.append(("Env file", ok, detail))
-
-        if "Google Drive" in failed_names:
-            ok, detail = attempt_google_token(
-                SCRIPT_DIR / "token.json",
-                ["https://www.googleapis.com/auth/drive.readonly"],
-            )
-            fix_actions.append(("Google Drive token", ok, detail))
-
-        if MSG_GOOGLE_DOCS_TOKEN in failed_names:
-            ok, detail = attempt_google_token(
-                SCRIPT_DIR / "token_docs.json",
-                [
-                    "https://www.googleapis.com/auth/drive.file",
-                    "https://www.googleapis.com/auth/documents",
-                ],
-            )
-            fix_actions.append((MSG_GOOGLE_DOCS_TOKEN, ok, detail))
-
-        for name, ok, detail in fix_actions:
-            print_result(f"{name} fix", ok, detail)
-
-        # Re-check after fixes
-        print()
-        print("Re-checking...")
-        failures = 0
-        for name, fn in checks:
-            ok, detail = fn()
-            print_result(name, ok, detail)
-            if not ok:
-                failures += 1
+        print("\nRe-checking...")
+        _, failures = _run_checks(checks)
 
     if failures:
         print(f"\n{failures} check(s) failed")


### PR DESCRIPTION
## Summary
- **upload_to_confluence.py:** `markdown_to_confluence` 22 → ~10 via 4 extracted helpers
- **upload_to_docs.py:** `markdown_to_docs_requests` 19 → ~8 via 3 extracted helpers
- **preflight_check.py:** `main` 23 → ~10 via 3 extracted helpers

All refactoring preserves existing behavior — logic moved into named functions without control flow changes.

## Test plan
- [ ] `python -m pytest scripts/tests/`
- [ ] Confirm SonarCloud no longer flags these functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)